### PR TITLE
response should write before onEnd invoked

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -161,9 +161,9 @@ Response.prototype.end = function (data, encoding, cb) {
 	self.statusCode = self.statusCode || 200;
 	self.statusMessage = STATUS_CODES[self.statusCode] || '';
 	self.headersSent = true;
+	Writable.prototype.end.call(self, data, encoding, cb);
 	clearTimeout(self._internal.timer);
 	self.emit('end');
-	Writable.prototype.end.call(self, data, encoding, cb);
 };
 
 /** @see http://nodejs.org/api/http.html#http_response_write_chunk_encoding */


### PR DESCRIPTION
as is, when my `onEnd()` callback is invoked, the last chunk (the one passed to `res.end()`) is not written to the buffer. that means my test code can not use `res.getBuffer()` and do anything useful with it. this slight reordering fixes that problem.
